### PR TITLE
Add "php type" to attribute

### DIFF
--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -11,6 +11,7 @@ class Attribute implements Arrayable
 
     public function __construct(
         public string $name,
+        public ?string $phpType,
         public ?string $type,
         public bool $increments,
         public ?bool $nullable,

--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -16,6 +16,7 @@ class Attribute implements Arrayable
         public bool $increments,
         public ?bool $nullable,
         public mixed $default,
+        public ?bool $primary,
         public ?bool $unique,
         public bool $fillable,
         public ?bool $appended,

--- a/src/Attributes/AttributeFinder.php
+++ b/src/Attributes/AttributeFinder.php
@@ -42,19 +42,24 @@ class AttributeFinder
 
         return collect($columns)
             ->values()
-            ->map(fn (Column $column) => new Attribute(
-                $column->getName(),
-                $this->getPhpType($column),
-                $this->getColumnType($column),
-                $column->getAutoincrement(),
-                ! $column->getNotnull(),
-                $this->getColumnDefault($column, $model),
-                $this->columnIsUnique($column->getName(), $indexes),
-                $model->isFillable($column->getName()),
-                null,
-                $this->getCastType($column->getName(), $model),
-                false,
-            ))
+            ->map(function (Column $column) use($model, $columns, $indexes) {
+                $columnIndexes = $this->getIndexes($column->getName(), $indexes);
+
+                return new Attribute(
+                    name: $column->getName(),
+                    phpType: $this->getPhpType($column),
+                    type: $this->getColumnType($column),
+                    increments: $column->getAutoincrement(),
+                    nullable: ! $column->getNotnull(),
+                    default: $this->getColumnDefault($column, $model),
+                    primary: $columnIndexes->contains(fn (Index $index) => $index->isPrimary()),
+                    unique: $columnIndexes->contains(fn (Index $index) => $index->isUnique()),
+                    fillable: $model->isFillable($column->getName()),
+                    appended: null,
+                    cast: $this->getCastType($column->getName(), $model),
+                    virtual: false,
+                );
+            })
             ->merge($this->getVirtualAttributes($model, $columns));
     }
 
@@ -115,15 +120,14 @@ class AttributeFinder
     }
 
     /**
-     * @param  string  $column
-     * @param  array<Index>  $indexes
-     * @return bool
+     * @param string $column
+     * @param Index[]  $indexes
+     *
+     * @return Collection<int, Index>
      */
-    protected function columnIsUnique(string $column, array $indexes): bool
-    {
+    protected function getIndexes(string $column, array $indexes) {
         return collect($indexes)
-            ->filter(fn (Index $index) => count($index->getColumns()) === 1 && $index->getColumns()[0] === $column)
-            ->contains(fn (Index $index) => $index->isUnique());
+            ->filter(fn (Index $index) => count($index->getColumns()) === 1 && $index->getColumns()[0] === $column);
     }
 
     protected function attributeIsHidden(string $attribute, Model $model): bool
@@ -197,17 +201,18 @@ class AttributeFinder
             })
             ->reject(fn ($cast, $name) => collect($columns)->has($name))
             ->map(fn ($cast, $name) => new Attribute(
-                $name,
-                $cast['php_type'] ?? null,
-                null,
-                false,
-                null,
-                null,
-                null,
-                $model->isFillable($name),
-                $model->hasAppended($name),
-                $cast['cast_type'],
-                true,
+                name: $name,
+                phpType: $cast['php_type'] ?? null,
+                type: null,
+                increments: false,
+                nullable: null,
+                default: null,
+                primary: null,
+                unique: null,
+                fillable: $model->isFillable($name),
+                appended: $model->hasAppended($name),
+                cast: $cast['cast_type'],
+                virtual: true,
             ))
             ->values();
     }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -8,9 +8,21 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 it('can get the attributes of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    expect($attributes)->toHaveCount(4);
+    expect($attributes)->toHaveCount(6);
 
     matchesAttributesSnapshot($attributes);
+});
+
+it('can get virtual attribute php types of a model', function () {
+    $attributes = AttributeFinder::forModel(new TestModel());
+
+    $titleUppercaseAttr         = $attributes->first(fn($attr) => $attr->name === 'title_uppercase');
+    $titleWithoutReturnTypeAttr = $attributes->first(fn($attr) => $attr->name === 'title_without_return_type');
+
+    $this->assertNotNull($titleUppercaseAttr);
+    $this->assertEquals('string', $titleUppercaseAttr->phpType);
+    $this->assertEquals(null, $titleWithoutReturnTypeAttr->phpType);
+
 });
 
 function matchesAttributesSnapshot(Collection $attributes)

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -6,4 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class TestModel extends Model
 {
+
+    public function getTitleUppercaseAttribute() : string
+    {
+        return strtoupper($this->title);
+    }
+
+    public function getTitleWithoutReturnTypeAttribute()
+    {
+        return $this->title;
+    }
+
 }

--- a/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
+++ b/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
@@ -1,5 +1,6 @@
 -
     name: id
+    phpType: int
     type: integer
     increments: true
     nullable: false
@@ -11,6 +12,7 @@
     virtual: false
 -
     name: name
+    phpType: string
     type: string
     increments: false
     nullable: false
@@ -22,6 +24,7 @@
     virtual: false
 -
     name: created_at
+    phpType: DateTime
     type: datetime
     increments: false
     nullable: true
@@ -33,6 +36,7 @@
     virtual: false
 -
     name: updated_at
+    phpType: DateTime
     type: datetime
     increments: false
     nullable: true
@@ -42,3 +46,27 @@
     appended: null
     cast: datetime
     virtual: false
+-
+    name: title_uppercase
+    phpType: string
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: accessor
+    virtual: true
+-
+    name: title_without_return_type
+    phpType: null
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: accessor
+    virtual: true

--- a/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
+++ b/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
@@ -5,6 +5,7 @@
     increments: true
     nullable: false
     default: null
+    primary: true
     unique: true
     fillable: false
     appended: null
@@ -17,6 +18,7 @@
     increments: false
     nullable: false
     default: null
+    primary: false
     unique: false
     fillable: false
     appended: null
@@ -29,6 +31,7 @@
     increments: false
     nullable: true
     default: null
+    primary: false
     unique: false
     fillable: false
     appended: null
@@ -41,6 +44,7 @@
     increments: false
     nullable: true
     default: null
+    primary: false
     unique: false
     fillable: false
     appended: null
@@ -53,6 +57,7 @@
     increments: false
     nullable: null
     default: null
+    primary: null
     unique: null
     fillable: false
     appended: false
@@ -65,6 +70,7 @@
     increments: false
     nullable: null
     default: null
+    primary: null
     unique: null
     fillable: false
     appended: false

--- a/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
+++ b/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
@@ -5,8 +5,8 @@ tableName: relation_test_models
 relations:
     - { name: user, type: BelongsTo, related: Illuminate\Foundation\Auth\User }
 attributes:
-    - { name: id, phpType: int, type: integer, increments: true, nullable: false, default: null, unique: true, fillable: false, appended: null, cast: int, virtual: false }
-    - { name: name, phpType: string, type: string, increments: false, nullable: false, default: null, unique: false, fillable: false, appended: null, cast: null, virtual: false }
-    - { name: created_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
-    - { name: updated_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
+    - { name: id, phpType: int, type: integer, increments: true, nullable: false, default: null, primary: true, unique: true, fillable: false, appended: null, cast: int, virtual: false }
+    - { name: name, phpType: string, type: string, increments: false, nullable: false, default: null, primary: false, unique: false, fillable: false, appended: null, cast: null, virtual: false }
+    - { name: created_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, primary: false, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
+    - { name: updated_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, primary: false, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
 extra: null

--- a/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
+++ b/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
@@ -5,8 +5,8 @@ tableName: relation_test_models
 relations:
     - { name: user, type: BelongsTo, related: Illuminate\Foundation\Auth\User }
 attributes:
-    - { name: id, type: integer, increments: true, nullable: false, default: null, unique: true, fillable: false, appended: null, cast: int, virtual: false }
-    - { name: name, type: string, increments: false, nullable: false, default: null, unique: false, fillable: false, appended: null, cast: null, virtual: false }
-    - { name: created_at, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
-    - { name: updated_at, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
+    - { name: id, phpType: int, type: integer, increments: true, nullable: false, default: null, unique: true, fillable: false, appended: null, cast: int, virtual: false }
+    - { name: name, phpType: string, type: string, increments: false, nullable: false, default: null, unique: false, fillable: false, appended: null, cast: null, virtual: false }
+    - { name: created_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
+    - { name: updated_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
 extra: null


### PR DESCRIPTION
- Adds a "phpType" string property to Attribute, containing the php type name of the column
- Adds a "primary" bool property to Attribute, containing whether or not it's a primary key

Please do let me know if anything needs to be adjusted, but this should be a nice addition :) 