### PR TITLE
Handle abstract model classes

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -37,6 +37,7 @@ class ModelFinder
             })
             ->filter()
             ->filter(fn (ReflectionClass $class) => $class->isSubclassOf(Model::class))
+            ->filter(fn (ReflectionClass $class) => !$class->isAbstract())
             ->map(fn (ReflectionClass $reflectionClass) => $reflectionClass->getName());
     }
 

--- a/tests/TestSupport/Models/AbstractBaseModel.php
+++ b/tests/TestSupport/Models/AbstractBaseModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelInfo\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractBaseModel extends Model
+{
+
+}


### PR DESCRIPTION
In our application, we have an abstract base model that contains many helper methods. Due to the model finder trying to create a new instance of all classes that extend Model, a `Cannot instantiate abstract class App\Models\BaseModel` exception gets thrown. This PR filters out the abstract models from being returned from the model finder.

Testing is covered via the `can discover all models in a directory` test, as I added an abstract model to the Models folder, and the count is still remains 3