### PR TITLE
Support any level of nested directories

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -6,8 +6,9 @@ use Error;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReflectionClass;
 use SplFileInfo;
 
@@ -23,9 +24,7 @@ class ModelFinder
         $basePath ??= base_path();
         $baseNamespace ??= '';
 
-        $globPattern = realpath($directory).'/**/*.php';
-
-        return collect(File::glob($globPattern))
+        return collect(static::getFilesRecursively($directory))
             ->map(fn (string $class) => new SplFileInfo($class))
             ->map(fn (SplFileInfo $file) => self::fullQualifiedClassNameFromFile($file, $basePath, $baseNamespace))
             ->map(function (string $class) {
@@ -55,5 +54,20 @@ class ModelFinder
                 ['\\', app()->getNamespace()],
             )
             ->prepend($baseNamespace.'\\');
+    }
+
+    protected static function getFilesRecursively(string $path): array
+    {
+        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+        $files = [];
+
+        foreach ($rii as $file) {
+            if ($file->isDir()) {
+                continue;
+            }
+            $files[] = $file->getPathname();
+        }
+
+        return $files;
     }
 }

--- a/tests/ModelFinderTest.php
+++ b/tests/ModelFinderTest.php
@@ -2,11 +2,13 @@
 
 namespace Spatie\ModelInfo\Tests;
 
-use ReflectionClass;
 use Spatie\ModelInfo\ModelFinder;
+use Spatie\ModelInfo\Tests\TestSupport\Models\ExtraModelInfoModel;
+use Spatie\ModelInfo\Tests\TestSupport\Models\Nested\Model\NestedModel;
 use Spatie\ModelInfo\Tests\TestSupport\Models\RelationTestModel;
+use Spatie\ModelInfo\Tests\TestSupport\Models\TestModel;
 
-it('can discover all models in a directory', function () {
+it('can discover all models in a directory', function() {
     $models = ModelFinder::all(
         $this->getTestSupportDirectory(),
         $this->getTestDirectory(),
@@ -15,8 +17,10 @@ it('can discover all models in a directory', function () {
 
     expect($models)->toHaveCount(4);
 
-    /** @var ReflectionClass $firstModel */
-    $firstModel = $models->first();
-
-    expect($firstModel)->toBe(RelationTestModel::class);
+    expect($models->toArray())->toEqualCanonicalizing([
+        NestedModel::class,
+        ExtraModelInfoModel::class,
+        RelationTestModel::class,
+        TestModel::class,
+    ]);
 });

--- a/tests/ModelFinderTest.php
+++ b/tests/ModelFinderTest.php
@@ -4,7 +4,7 @@ namespace Spatie\ModelInfo\Tests;
 
 use ReflectionClass;
 use Spatie\ModelInfo\ModelFinder;
-use Spatie\ModelInfo\Tests\TestSupport\Models\ExtraModelInfoModel;
+use Spatie\ModelInfo\Tests\TestSupport\Models\RelationTestModel;
 
 it('can discover all models in a directory', function () {
     $models = ModelFinder::all(
@@ -13,10 +13,10 @@ it('can discover all models in a directory', function () {
         "Spatie\ModelInfo\Tests",
     );
 
-    expect($models)->toHaveCount(3);
+    expect($models)->toHaveCount(4);
 
     /** @var ReflectionClass $firstModel */
     $firstModel = $models->first();
 
-    expect($firstModel)->toBe(ExtraModelInfoModel::class);
+    expect($firstModel)->toBe(RelationTestModel::class);
 });

--- a/tests/ModelInfoTest.php
+++ b/tests/ModelInfoTest.php
@@ -23,7 +23,7 @@ it('can get meta information about all models', function () {
         "Spatie\ModelInfo\Tests",
     );
 
-    expect($modelInfo)->toHaveCount(3);
+    expect($modelInfo)->toHaveCount(4);
     expect($modelInfo->first())->toBeInstanceOf(ModelInfo::class);
 });
 

--- a/tests/TestSupport/Models/Nested/Model/NestedModel.php
+++ b/tests/TestSupport/Models/Nested/Model/NestedModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelInfo\Tests\TestSupport\Models\Nested\Model;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NestedModel extends Model
+{
+}


### PR DESCRIPTION
TIL php's `glob()` function does not support globstar (**), and treats it as a single *. This means that the Model finder is only matching php model classes that are one level deep. Based on my research, i can't find anything that would suggest that you can change that. Due to this, I have replaced the glob match with a `RecursiveDirectoryIterator` that will retrieve model files that are nested any level deep