### PR TITLE
Return 0-indexed array from ModelFinder

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -37,7 +37,8 @@ class ModelFinder
             ->filter()
             ->filter(fn (ReflectionClass $class) => $class->isSubclassOf(Model::class))
             ->filter(fn (ReflectionClass $class) => ! $class->isAbstract())
-            ->map(fn (ReflectionClass $reflectionClass) => $reflectionClass->getName());
+            ->map(fn (ReflectionClass $reflectionClass) => $reflectionClass->getName())
+            ->values();
     }
 
     protected static function fullQualifiedClassNameFromFile(


### PR DESCRIPTION
Currently in the ModelFinder when results are returned, they are not 0-indexed because of the filtering happening. This change adds a call to ->values() after all of the models are processed to ensure a 0-indexed array is returned.