### PR TITLE
Support for doctrine/dbal 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^3.4",
+        "doctrine/dbal": "^2.13.3|^3.4",
         "illuminate/database": "^9.23",
         "spatie/laravel-package-tools": "^1.9.2"
     },


### PR DESCRIPTION
Working on an older project where doctrine 2 is being used instead of 3, and upgrading to 3 is not an option at the moment. That is my problem, however laravel framework itself is suggesting that versions 2 and 3 are supported ([see here](https://github.com/laravel/framework/blob/9.x/composer.json#L150)), so I believe that the package should also support these versions.