### PR TITLE
Add Trait information to model info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpunit/phpunit": "^9.5",
-        "spatie/pest-plugin-snapshots": "^1.1"}
-,
+        "spatie/pest-plugin-snapshots": "^1.1",
+        "symfony/serializer": "^6"
+    },
     "autoload": {
         "psr-4": {
             "Spatie\\ModelInfo\\": "src"

--- a/src/ModelInfo.php
+++ b/src/ModelInfo.php
@@ -50,6 +50,7 @@ class ModelInfo
             $model->getConnection()->getTablePrefix().$model->getTable(),
             RelationFinder::forModel($model),
             AttributeFinder::forModel($model),
+            self::getTraits($model),
             self::getExtraModelInfo($model),
         );
     }
@@ -61,6 +62,7 @@ class ModelInfo
         public string $tableName,
         public Collection $relations,
         public Collection $attributes,
+        public Collection $traits,
         public mixed $extra = null,
     ) {
     }
@@ -72,6 +74,11 @@ class ModelInfo
         }
 
         return null;
+    }
+
+    protected static function getTraits(Model $model): Collection
+    {
+        return collect(array_values(class_uses($model)));
     }
 
     public function toArray(): array

--- a/tests/ModelFinderTest.php
+++ b/tests/ModelFinderTest.php
@@ -7,6 +7,7 @@ use Spatie\ModelInfo\Tests\TestSupport\Models\ExtraModelInfoModel;
 use Spatie\ModelInfo\Tests\TestSupport\Models\Nested\Model\NestedModel;
 use Spatie\ModelInfo\Tests\TestSupport\Models\RelationTestModel;
 use Spatie\ModelInfo\Tests\TestSupport\Models\TestModel;
+use Spatie\ModelInfo\Tests\TestSupport\Models\TraitTestModel;
 
 it('can discover all models in a directory', function () {
     $models = ModelFinder::all(
@@ -15,12 +16,13 @@ it('can discover all models in a directory', function () {
         "Spatie\ModelInfo\Tests",
     );
 
-    expect($models)->toHaveCount(4);
+    expect($models)->toHaveCount(5);
 
     expect($models->toArray())->toEqualCanonicalizing([
         NestedModel::class,
         ExtraModelInfoModel::class,
         RelationTestModel::class,
         TestModel::class,
+        TraitTestModel::class,
     ]);
 });

--- a/tests/ModelInfoTest.php
+++ b/tests/ModelInfoTest.php
@@ -5,6 +5,8 @@ use Illuminate\Foundation\Auth\User;
 use Spatie\ModelInfo\ModelInfo;
 use Spatie\ModelInfo\Tests\TestSupport\Models\ExtraModelInfoModel;
 use Spatie\ModelInfo\Tests\TestSupport\Models\RelationTestModel;
+use Spatie\ModelInfo\Tests\TestSupport\Models\TraitTestModel;
+use Spatie\ModelInfo\Tests\TestSupport\Traits\TestTrait;
 
 it('can get meta information about a model', function () {
     $modelInfo = ModelInfo::forModel(RelationTestModel::class);
@@ -23,7 +25,7 @@ it('can get meta information about all models', function () {
         "Spatie\ModelInfo\Tests",
     );
 
-    expect($modelInfo)->toHaveCount(4);
+    expect($modelInfo)->toHaveCount(5);
     expect($modelInfo->first())->toBeInstanceOf(ModelInfo::class);
 });
 
@@ -31,6 +33,12 @@ it('can get extra info from a model', function () {
     $modelInfo = ModelInfo::forModel(ExtraModelInfoModel::class);
 
     expect($modelInfo->extra)->toBe('extra info');
+});
+
+it('can get traits from a model', function () {
+    $modelInfo = ModelInfo::forModel(TraitTestModel::class);
+
+    expect($modelInfo->traits->first())->toBe(TestTrait::class);
 });
 
 it('can get a specific attribute', function () {

--- a/tests/TestSupport/Models/TraitTestModel.php
+++ b/tests/TestSupport/Models/TraitTestModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\ModelInfo\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelInfo\Tests\TestSupport\Traits\TestTrait;
+
+class TraitTestModel extends Model
+{
+    use TestTrait;
+}

--- a/tests/TestSupport/Traits/TestTrait.php
+++ b/tests/TestSupport/Traits/TestTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelInfo\Tests\TestSupport\Traits;
+
+trait TestTrait
+{
+}

--- a/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
+++ b/tests/__snapshots__/ModelInfoTest__it_can_get_meta_information_about_a_model__1.yml
@@ -9,4 +9,5 @@ attributes:
     - { name: name, phpType: string, type: string, increments: false, nullable: false, default: null, primary: false, unique: false, fillable: false, appended: null, cast: null, virtual: false }
     - { name: created_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, primary: false, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
     - { name: updated_at, phpType: DateTime, type: datetime, increments: false, nullable: true, default: null, primary: false, unique: false, fillable: false, appended: null, cast: datetime, virtual: false }
+traits: {  }
 extra: null


### PR DESCRIPTION
Adds a `traits` property to the model info. Among other purposes, it can be used to tell if a model is using soft deletes.