### PR TITLE
Detect mutators

### DIFF
--- a/src/Attributes/AttributeFinder.php
+++ b/src/Attributes/AttributeFinder.php
@@ -195,6 +195,15 @@ class AttributeFinder
                     ];
                 }
 
+                if (preg_match('/^set(.*)Attribute$/', $method->getName(), $matches) === 1) {
+                    return [
+                        Str::snake($matches[1]) => [
+                            'cast_type' => 'mutator',
+                            'php_type' => collect($method->getParameters())->firstWhere('name', 'value')?->getType()?->__toString(),
+                        ],
+                    ];
+                }
+
                 if ($model->hasAttributeMutator($method->getName())) {
                     return [
                         Str::snake($method->getName()) => [

--- a/src/Attributes/AttributeFinder.php
+++ b/src/Attributes/AttributeFinder.php
@@ -181,43 +181,41 @@ class AttributeFinder
         $class = new ReflectionClass($model);
 
         return collect($class->getMethods())
-            ->reject(fn (ReflectionMethod $method) => $method->isStatic()
-                || $method->isAbstract()
-                || $method->getDeclaringClass()->getName() !== get_class($model)
+            ->reject(
+                fn (ReflectionMethod $method) => $method->isStatic()
+                    || $method->isAbstract()
+                    || $method->getDeclaringClass()->getName() !== get_class($model)
             )
-            ->mapWithKeys(function (ReflectionMethod $method) use ($model) {
+            ->map(function (ReflectionMethod $method) use ($model) {
                 if (preg_match('/^get(.*)Attribute$/', $method->getName(), $matches) === 1) {
                     return [
-                        Str::snake($matches[1]) => [
-                            'cast_type' => 'accessor',
-                            'php_type' => $method->getReturnType()?->getName(),
-                        ],
+                        'name' => Str::snake($matches[1]),
+                        'cast_type' => 'accessor',
+                        'php_type' => $method->getReturnType()?->getName(),
                     ];
                 }
 
                 if (preg_match('/^set(.*)Attribute$/', $method->getName(), $matches) === 1) {
                     return [
-                        Str::snake($matches[1]) => [
-                            'cast_type' => 'mutator',
-                            'php_type' => collect($method->getParameters())->firstWhere('name', 'value')?->getType()?->__toString(),
-                        ],
+                        'name' => Str::snake($matches[1]),
+                        'cast_type' => 'mutator',
+                        'php_type' => collect($method->getParameters())->firstWhere('name', 'value')?->getType()?->__toString(),
                     ];
                 }
 
                 if ($model->hasAttributeMutator($method->getName())) {
                     return [
-                        Str::snake($method->getName()) => [
-                            'cast_type' => 'attribute',
-                            'php_type' => null,
-                        ],
+                        'name' => Str::snake($method->getName()),
+                        'cast_type' => 'attribute',
+                        'php_type' => null,
                     ];
                 }
 
                 return [];
             })
-            ->reject(fn ($cast, $name) => collect($columns)->has($name))
-            ->map(fn ($cast, $name) => new Attribute(
-                name: $name,
+            ->reject(fn ($cast) => ! isset($cast['name']) || collect($columns)->has($cast['name']))
+            ->map(fn ($cast) => new Attribute(
+                name: $cast['name'],
                 phpType: $cast['php_type'] ?? null,
                 type: null,
                 increments: false,
@@ -225,12 +223,28 @@ class AttributeFinder
                 default: null,
                 primary: null,
                 unique: null,
-                fillable: $model->isFillable($name),
-                appended: $model->hasAppended($name),
+                fillable: $model->isFillable($cast['name']),
+                appended: $model->hasAppended($cast['name']),
                 cast: $cast['cast_type'],
                 virtual: true,
-                hidden: $this->attributeIsHidden($name, $model)
+                hidden: $this->attributeIsHidden($cast['name'], $model)
             ))
-            ->values();
+            // Convert duplicate entries for accessor-mutator combinations
+            ->groupBy('name')
+            ->flatMap(function (Collection $items) {
+                if ($items->count() !== 2) {
+                    return $items;
+                }
+
+                if (! $items->firstWhere('cast', 'accessor') || ! $items->firstWhere('cast', 'mutator')) {
+                    return $items;
+                }
+
+                $attribute = $items->first();
+                $attribute->phpType = $items[0]->phpType ?? $items[1]->phpType;
+                $attribute->cast = 'attribute';
+
+                return [$attribute];
+            });
     }
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -14,10 +14,12 @@ it('can get the attributes of a model', function () {
     matchesAttributesSnapshot($attributes);
 });
 
-it('can get virtual attribute php types of a model', function () {
+/**
+ * @see https://laravel.com/docs/8.x/eloquent-mutators#defining-an-accessor
+ */
+it('can get the accessor attributes of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    // Laravel 8 style accessors
     $titleUppercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_uppercase');
     $titleWithoutReturnTypeAttr = $attributes->first(fn ($attr) => $attr->name === 'title_without_return_type');
 
@@ -29,8 +31,14 @@ it('can get virtual attribute php types of a model', function () {
         ->cast->toBe('accessor')
         ->not()->toBeNull()
         ->phpType->toBeNull();
+});
 
-    // Laravel 8 style mutators
+/**
+ * @see https://laravel.com/docs/8.x/eloquent-mutators#defining-a-mutator
+ */
+it('can get the mutator attributes of a model', function () {
+    $attributes = AttributeFinder::forModel(new TestModel());
+
     $passwordMutatorAttr = $attributes->first(fn ($attr) => $attr->name === 'encrypted_password');
     $passwordMutatorWithoutTypeHintAttr = $attributes->first(fn ($attr) => $attr->name === 'trimmed_and_encrypted_password');
 
@@ -42,16 +50,27 @@ it('can get virtual attribute php types of a model', function () {
         ->cast->toBe('mutator')
         ->not()->toBeNull()
         ->phpType->toBeNull();
+});
 
-    // Laravel 8 style accessor & mutators
+it('can handle accessor-mutator combinations', function () {
+    $attributes = AttributeFinder::forModel(new TestModel());
+
     $dottedNameAttr = $attributes->first(fn ($attr) => $attr->name === 'dotted_name');
 
     expect($dottedNameAttr)
         ->cast->toBe('attribute')
         ->not()->toBeNull()
         ->phpType->toBe('string');
+    expect($attributes->where('name', 'dotted_name')->count())
+        ->toBe(1);
+});
 
-    // Laravel 9 style attributes
+/**
+ * @see https://laravel.com/docs/9.x/eloquent-mutators#accessors-and-mutators
+ */
+it('can handle virtual attributes of a model', function () {
+    $attributes = AttributeFinder::forModel(new TestModel());
+
     $titleLowercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_lowercase');
 
     expect($titleLowercaseAttr)

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -9,7 +9,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 it('can get the attributes of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    expect($attributes)->toHaveCount(8);
+    expect($attributes)->toHaveCount(10);
 
     matchesAttributesSnapshot($attributes);
 });
@@ -17,7 +17,7 @@ it('can get the attributes of a model', function () {
 it('can get virtual attribute php types of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    // Laravel 8 style accessors and mutators
+    // Laravel 8 style accessors
     $titleUppercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_uppercase');
     $titleWithoutReturnTypeAttr = $attributes->first(fn ($attr) => $attr->name === 'title_without_return_type');
 
@@ -25,6 +25,17 @@ it('can get virtual attribute php types of a model', function () {
         ->not()->toBeNull()
         ->phpType->toBe('string');
     expect($titleWithoutReturnTypeAttr)
+        ->not()->toBeNull()
+        ->phpType->toBeNull();
+
+    // Laravel 8 style mutators
+    $passwordMutatorAttr = $attributes->first(fn ($attr) => $attr->name === 'encrypted_password');
+    $passwordMutatorWithoutTypeHintAttr = $attributes->first(fn ($attr) => $attr->name === 'trimmed_and_encrypted_password');
+
+    expect($passwordMutatorAttr)
+        ->not()->toBeNull()
+        ->phpType->toBe('string');
+    expect($passwordMutatorWithoutTypeHintAttr)
         ->not()->toBeNull()
         ->phpType->toBeNull();
 

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -9,7 +9,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 it('can get the attributes of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    expect($attributes)->toHaveCount(7);
+    expect($attributes)->toHaveCount(8);
 
     matchesAttributesSnapshot($attributes);
 });
@@ -17,6 +17,7 @@ it('can get the attributes of a model', function () {
 it('can get virtual attribute php types of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
+    // Laravel 8 style accessors and mutators
     $titleUppercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_uppercase');
     $titleWithoutReturnTypeAttr = $attributes->first(fn ($attr) => $attr->name === 'title_without_return_type');
 
@@ -24,6 +25,13 @@ it('can get virtual attribute php types of a model', function () {
         ->not()->toBeNull()
         ->phpType->toBe('string');
     expect($titleWithoutReturnTypeAttr)
+        ->not()->toBeNull()
+        ->phpType->toBeNull();
+
+    // Laravel 9 style attributes
+    $titleLowercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_lowercase');
+
+    expect($titleLowercaseAttr)
         ->not()->toBeNull()
         ->phpType->toBeNull();
 });

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -20,9 +20,12 @@ it('can get virtual attribute php types of a model', function () {
     $titleUppercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_uppercase');
     $titleWithoutReturnTypeAttr = $attributes->first(fn ($attr) => $attr->name === 'title_without_return_type');
 
-    $this->assertNotNull($titleUppercaseAttr);
-    $this->assertEquals('string', $titleUppercaseAttr->phpType);
-    $this->assertEquals(null, $titleWithoutReturnTypeAttr->phpType);
+    expect($titleUppercaseAttr)
+        ->not()->toBeNull()
+        ->phpType->toBe('string');
+    expect($titleWithoutReturnTypeAttr)
+        ->not()->toBeNull()
+        ->phpType->toBeNull();
 });
 
 it('can get extended column types for a model', function () {

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -9,7 +9,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 it('can get the attributes of a model', function () {
     $attributes = AttributeFinder::forModel(new TestModel());
 
-    expect($attributes)->toHaveCount(10);
+    expect($attributes)->toHaveCount(11);
 
     matchesAttributesSnapshot($attributes);
 });
@@ -22,9 +22,11 @@ it('can get virtual attribute php types of a model', function () {
     $titleWithoutReturnTypeAttr = $attributes->first(fn ($attr) => $attr->name === 'title_without_return_type');
 
     expect($titleUppercaseAttr)
+        ->cast->toBe('accessor')
         ->not()->toBeNull()
         ->phpType->toBe('string');
     expect($titleWithoutReturnTypeAttr)
+        ->cast->toBe('accessor')
         ->not()->toBeNull()
         ->phpType->toBeNull();
 
@@ -33,16 +35,27 @@ it('can get virtual attribute php types of a model', function () {
     $passwordMutatorWithoutTypeHintAttr = $attributes->first(fn ($attr) => $attr->name === 'trimmed_and_encrypted_password');
 
     expect($passwordMutatorAttr)
+        ->cast->toBe('mutator')
         ->not()->toBeNull()
         ->phpType->toBe('string');
     expect($passwordMutatorWithoutTypeHintAttr)
+        ->cast->toBe('mutator')
         ->not()->toBeNull()
         ->phpType->toBeNull();
+
+    // Laravel 8 style accessor & mutators
+    $dottedNameAttr = $attributes->first(fn ($attr) => $attr->name === 'dotted_name');
+
+    expect($dottedNameAttr)
+        ->cast->toBe('attribute')
+        ->not()->toBeNull()
+        ->phpType->toBe('string');
 
     // Laravel 9 style attributes
     $titleLowercaseAttr = $attributes->first(fn ($attr) => $attr->name === 'title_lowercase');
 
     expect($titleLowercaseAttr)
+        ->cast->toBe('attribute')
         ->not()->toBeNull()
         ->phpType->toBeNull();
 });

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -21,6 +21,16 @@ class TestModel extends Model
         return $this->title;
     }
 
+    public function setEncryptedPasswordAttribute(string $value)
+    {
+        $this->password = bcrypt($value);
+    }
+
+    public function setTrimmedAndEncryptedPasswordAttribute($value)
+    {
+        $this->password = bcrypt(trim($value));
+    }
+
     public function titleLowercase(): Attribute
     {
         return Attribute::make(

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -37,4 +37,14 @@ class TestModel extends Model
             get: fn ($value) => strtolower($value)
         );
     }
+
+    public function getDottedNameAttribute(): string
+    {
+        return str_replace(' ', '.', $this->name);
+    }
+
+    public function setDottedNameAttribute(string $value)
+    {
+        $this->name = str_replace('.', ' ', $value);
+    }
 }

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ModelInfo\Tests\TestSupport\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 class TestModel extends Model
@@ -18,5 +19,12 @@ class TestModel extends Model
     public function getTitleWithoutReturnTypeAttribute()
     {
         return $this->title;
+    }
+
+    public function titleLowercase(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => strtolower($value)
+        );
     }
 }

--- a/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
+++ b/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
@@ -96,3 +96,17 @@
     cast: accessor
     virtual: true
     hidden: false
+-
+    name: title_lowercase
+    phpType: null
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    primary: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: attribute
+    virtual: true
+    hidden: false

--- a/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
+++ b/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
@@ -97,6 +97,34 @@
     virtual: true
     hidden: false
 -
+    name: encrypted_password
+    phpType: string
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    primary: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: mutator
+    virtual: true
+    hidden: false
+-
+    name: trimmed_and_encrypted_password
+    phpType: null
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    primary: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: mutator
+    virtual: true
+    hidden: false
+-
     name: title_lowercase
     phpType: null
     type: null

--- a/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
+++ b/tests/__snapshots__/AttributeTest__it_can_get_the_attributes_of_a_model__1.yml
@@ -138,3 +138,17 @@
     cast: attribute
     virtual: true
     hidden: false
+-
+    name: dotted_name
+    phpType: string
+    type: null
+    increments: false
+    nullable: null
+    default: null
+    primary: null
+    unique: null
+    fillable: false
+    appended: false
+    cast: attribute
+    virtual: true
+    hidden: false


### PR DESCRIPTION
This PR introduces the capability to handle Laravel 8 style (and below) mutators as well as accessor-mutator combinations.

The logic was implemented as described here:
https://github.com/spatie/laravel-model-info/discussions/12#discussioncomment-3674158

To avoid duplicate entries for accessor-mutator combinations, I had to refactor the logic within `src/Attributes/AttributeFinder.php` a little. The other changes should be fairly easy to understand.