### PR TITLE
change preg_match in AttributeFinder.php to match the laravel behaviour

### DIFF
--- a/src/Attributes/AttributeFinder.php
+++ b/src/Attributes/AttributeFinder.php
@@ -187,7 +187,7 @@ class AttributeFinder
                     || $method->getDeclaringClass()->getName() !== get_class($model)
             )
             ->map(function (ReflectionMethod $method) use ($model) {
-                if (preg_match('/^get(.*)Attribute$/', $method->getName(), $matches) === 1) {
+                if (preg_match('/(?<=^|;)get([^;]+?)Attribute(;|$)/', $method->getName(), $matches) === 1) {
                     return [
                         'name' => Str::snake($matches[1]),
                         'cast_type' => 'accessor',
@@ -195,7 +195,7 @@ class AttributeFinder
                     ];
                 }
 
-                if (preg_match('/^set(.*)Attribute$/', $method->getName(), $matches) === 1) {
+                if (preg_match('/(?<=^|;)set([^;]+?)Attribute(;|$)/', $method->getName(), $matches) === 1) {
                     return [
                         'name' => Str::snake($matches[1]),
                         'cast_type' => 'mutator',

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -47,4 +47,14 @@ class TestModel extends Model
     {
         $this->name = str_replace('.', ' ', $value);
     }
+
+    public function setAttribute($key, $value)
+    {
+        parent::setAttribute($key, $value);
+    }
+
+    public function getAttribute($key)
+    {
+        parent::getAttribute($key);
+    }
 }


### PR DESCRIPTION
I have a trait that overrides the setAttribute and getAttribute method which resulted in attributes without a name.

This pull request changes the matching to the same regex as laravels HasAttributes trait does.