### PR TITLE
add try catch to RelationFinder.php when invoking

### DIFF
--- a/src/Relations/RelationFinder.php
+++ b/src/Relations/RelationFinder.php
@@ -38,14 +38,19 @@ class RelationFinder
             ->filter(fn (ReflectionMethod $method) => $this->hasRelationReturnType($method))
             ->map(function (ReflectionMethod $method) use ($model) {
                 /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
-                $relation = $method->invoke($model);
+                try {
+                    $relation = $method->invoke($model);
+                } catch (\Throwable $e) {
+                    return;
+                }
 
                 return new Relation(
                     $method->getName(),
                     $method->getReturnType(),
                     $relation->getRelated()::class,
                 );
-            });
+            })
+            ->filter(fn ($relation) => $relation instanceof Relation);
     }
 
     protected function hasRelationReturnType(

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -4,6 +4,7 @@ namespace Spatie\ModelInfo\Tests\TestSupport\Models;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TestModel extends Model
 {
@@ -56,5 +57,10 @@ class TestModel extends Model
     public function getAttribute($key)
     {
         parent::getAttribute($key);
+    }
+
+    public function exceptionRelation(): BelongsTo
+    {
+        throw new \Exception('This relation throws an exception');
     }
 }


### PR DESCRIPTION
Hi,

when using the free spatie media library package the temporaryUpload relation throws an exception which causes the modelinfo to stop.