### PR TITLE
The bug that occurred when any timestamp was defined as null

### DIFF
--- a/src/Attributes/AttributeFinder.php
+++ b/src/Attributes/AttributeFinder.php
@@ -166,6 +166,7 @@ class AttributeFinder
     protected function getCastsWithDates(Model $model): Collection
     {
         return collect($model->getDates())
+            ->whereNotNull()
             ->flip()
             ->map(fn () => 'datetime')
             ->merge($model->getCasts());


### PR DESCRIPTION
The bug that occurred when any timestamp was defined as null in the Eloquent model was fixed.

```php
use Illuminate\Database\Eloquent\Model;

class ModelWithoutUpdatedAt extends Model
{
    public const UPDATED_AT = null;
}
``` 

```
[2024-02-10 19:15:57] local.ERROR: array_flip(): Can only flip string and integer values, entry skipped {"exception":"[object] (ErrorException(code: 0): array_flip(): Can only flip string and integer values, entry skipped at /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Collection.php:425)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(425): array_flip()
#3 /var/www/html/vendor/spatie/laravel-model-info/src/Attributes/AttributeFinder.php(169): Illuminate\\Support\\Collection->flip()
#4 /var/www/html/vendor/spatie/laravel-model-info/src/Attributes/AttributeFinder.php(163): Spatie\\ModelInfo\\Attributes\\AttributeFinder->getCastsWithDates()
#5 /var/www/html/vendor/spatie/laravel-model-info/src/Attributes/AttributeFinder.php(65): Spatie\\ModelInfo\\Attributes\\AttributeFinder->getCastType()
#6 [internal function]: Spatie\\ModelInfo\\Attributes\\AttributeFinder->Spatie\\ModelInfo\\Attributes\\{closure}()
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(558): array_map()
#8 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(777): Illuminate\\Support\\Arr::map()
#9 /var/www/html/vendor/spatie/laravel-model-info/src/Attributes/AttributeFinder.php(51): Illuminate\\Support\\Collection->map()
#10 /var/www/html/vendor/spatie/laravel-model-info/src/Attributes/AttributeFinder.php(32): Spatie\\ModelInfo\\Attributes\\AttributeFinder->attributes()
#11 /var/www/html/vendor/spatie/laravel-model-info/src/ModelInfo.php(57): Spatie\\ModelInfo\\Attributes\\AttributeFinder::forModel()
#12 /var/www/html/vendor/spatie/laravel-model-info/src/ModelInfo.php(31): Spatie\\ModelInfo\\ModelInfo::forModel()
#13 [internal function]: Spatie\\ModelInfo\\ModelInfo::Spatie\\ModelInfo\\{closure}()
#14 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(558): array_map()
#15 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(777): Illuminate\\Support\\Arr::map()
#16 /var/www/html/vendor/spatie/laravel-model-info/src/ModelInfo.php(30): Illuminate\\Support\\Collection->map()
...
``` 