### PR TITLE
Update on ModelFinder.php to work with Laravel Modules.

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -46,6 +46,9 @@ class ModelFinder
         string $basePath,
         string $baseNamespace
     ): string {
+
+        $_app = ($baseNamespace != '') ? '' : app()->getNamespace();
+
         return Str::of($file->getRealPath())
             ->replaceFirst($basePath, '')
             ->replaceLast('.php', '')
@@ -53,7 +56,7 @@ class ModelFinder
             ->ucfirst()
             ->replace(
                 [DIRECTORY_SEPARATOR, 'App\\'],
-                ['\\', app()->getNamespace()],
+                ['\\', $_app],
             )
             ->prepend($baseNamespace.'\\');
     }

--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -70,6 +70,9 @@ class ModelFinder
             if ($file->isDir()) {
                 continue;
             }
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
             $files[] = $file->getPathname();
         }
 


### PR DESCRIPTION
Laravel Modules (https://laravelmodules.com/) is a smart tool to work with modules on Laravel. 

I made a small change to allow laravel-model-info to work with Laravel Modules.

To call ModelFinder, I use the following code:

```
        $return[app()->getNamespace()] = ModelFinder::all();
        $modules = Module::all();
        foreach ($modules as $module) {
            $base_path = $module->getPath();
            $base_path = str_replace('/', '\\', $base_path);
            $app_path = $base_path . '\app';
            $return[$module->getName()] = ModelFinder::all($app_path, $base_path, '\Modules\\' . $module->getName());
        }
        return $return;
```